### PR TITLE
Update DICTURL: raw.github.com has moved to raw.githubusercontent.com

### DIFF
--- a/bin/sekka-server
+++ b/bin/sekka-server
@@ -11,7 +11,7 @@ require 'sekka/sekkaversion'
 
 
 DICTDIR = File.expand_path( "~/.sekka-server" )
-DICTURL = "https://raw.github.com/kiyoka/sekka/master/public_dict/" + SekkaVersion.dictVersion
+DICTURL = "https://raw.githubusercontent.com/kiyoka/sekka/master/public_dict/" + SekkaVersion.dictVersion
 
 
 PIDFILE = DICTDIR + "/pid"


### PR DESCRIPTION
Details: https://developer.github.com/changes/2014-04-25-user-content-security/

When setting up sekka for the first time on my system, `tsvurl` was assigned an empty string because of the hostname change, combined with the fact that curl is instructed not to follow redirects.
