### PR TITLE
README に MELPA インストール手順を追記 (issue #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,64 @@ Sekkaには日本語モードがありません。
 
 ## インストール
 
-1. Melpaから`sekka`パッケージをインストールしてください。
-2. .emacsに以下を追記すると、Sekkaが有効になります。
+Sekka は [MELPA](https://melpa.org/) から `M-x package-install` でインストールできます。
+
+### 1. MELPA を `package-archives` に追加
+
+`~/.emacs.d/init.el` (または `~/.emacs`) に以下を追記してください。MELPA を既に追加済みなら不要です。
+
+```elisp
+(require 'package)
+(add-to-list 'package-archives
+             '("melpa" . "https://melpa.org/packages/") t)
+(package-initialize)
+```
+
+### 2. パッケージをインストール
 
 ```
+M-x package-refresh-contents RET
+M-x package-install RET sekka RET
+```
+
+### 3. Sekka を有効化
+
+`init.el` に以下を追記します。
+
+```elisp
 (require 'sekka)
 (global-sekka-mode 1)
 ```
 
+`use-package` を使う場合の例:
+
+```elisp
+(use-package sekka
+  :ensure t
+  :config
+  (global-sekka-mode 1))
+```
+
 ![enabled]( ./doc/img/sekka.modeline.png )
+
+### 辞書ファイルについて
+
+初回起動時に、変換用の辞書ファイルが `~/.emacs.d/sekka/` (デフォルト) へ
+GitHub から自動的にダウンロードされます。2 回目以降はキャッシュを利用するため、
+オフラインでも動作します。
+
+ダウンロード元やキャッシュ先は以下の変数でカスタマイズできます。
+
+| 変数 | デフォルト | 役割 |
+|---|---|---|
+| `sekka-dictionary-base-url` | `https://raw.githubusercontent.com/kiyoka/sekka/master/data/` | 辞書ダウンロード元 URL |
+| `sekka-dictionary-cache-dir` | `~/.emacs.d/sekka/` | キャッシュ先ディレクトリ |
+
+事前に辞書をダウンロードしておきたい場合は、以下を実行してください。
+
+```
+M-x sekka-jisyo-download-dictionaries
+```
 
 ----
 


### PR DESCRIPTION
## Summary

- README の「インストール」節を MELPA 経由のフルセットアップ手順に書き直し
- `package-archives` への MELPA 追加 / `package-install` 手順 / `use-package` 設定例を追加
- 初回起動時の辞書自動ダウンロードと `sekka-dictionary-base-url` / `sekka-dictionary-cache-dir` のカスタマイズ方法を追記
- `M-x sekka-jisyo-download-dictionaries` での事前ダウンロードを案内

## Test plan

- [x] 真っさらな Debian 環境で README の手順通りに `package-install sekka` → `global-sekka-mode 1` まで実行し、変換動作まで確認済み

Closes #17